### PR TITLE
Remove auth requirement from chat endpoints

### DIFF
--- a/api.py
+++ b/api.py
@@ -254,7 +254,7 @@ class SocialReport(Base):
 
 class ChatRoom(Base):
     __tablename__ = 'chat_rooms'
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id = Column(Integer, primary_key=True, autoincrement=True)
     user1_id = Column(Integer, ForeignKey('users.id'), nullable=False)
     user2_id = Column(Integer, ForeignKey('users.id'), nullable=False)
     is_active = Column(Boolean, default=True)
@@ -263,8 +263,8 @@ class ChatRoom(Base):
 
 class ChatMessage(Base):
     __tablename__ = 'chat_messages'
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    chat_room_id = Column(UUID(as_uuid=True), ForeignKey('chat_rooms.id'), nullable=False)
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    chat_room_id = Column(Integer, ForeignKey('chat_rooms.id'), nullable=False)
     sender_id = Column(Integer, ForeignKey('users.id'), nullable=False)
     message_text = Column(Text)
     media_url = Column(Text)
@@ -275,8 +275,8 @@ class ChatMessage(Base):
 class ChatReport(Base):
     __tablename__ = 'chat_reports'
     id = Column(Integer, primary_key=True, autoincrement=True)
-    chat_room_id = Column(UUID(as_uuid=True), ForeignKey('chat_rooms.id'), nullable=False)
-    message_id = Column(UUID(as_uuid=True), ForeignKey('chat_messages.id'), nullable=False)
+    chat_room_id = Column(Integer, ForeignKey('chat_rooms.id'), nullable=False)
+    message_id = Column(Integer, ForeignKey('chat_messages.id'), nullable=False)
     reported_by = Column(Integer, ForeignKey('users.id'), nullable=False)
     report_type = Column(String(50))
     action_taken = Column(Boolean, default=False)
@@ -1427,13 +1427,17 @@ async def update_user_profile(
 @app.post("/chat/create-room")
 def create_chat_room(
     user2_id: int,
-    current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db)
 ):
+    """Create a chat room without requiring authentication.
+
+    The current user is assumed to be user id 3.
+    """
+    current_user_id = 3
     # Check if room already exists
     existing_room = db.query(ChatRoom).filter(
-        ((ChatRoom.user1_id == current_user.id) & (ChatRoom.user2_id == user2_id)) |
-        ((ChatRoom.user1_id == user2_id) & (ChatRoom.user2_id == current_user.id))
+        ((ChatRoom.user1_id == current_user_id) & (ChatRoom.user2_id == user2_id)) |
+        ((ChatRoom.user1_id == user2_id) & (ChatRoom.user2_id == current_user_id))
     ).first()
     
     if existing_room:
@@ -1446,7 +1450,7 @@ def create_chat_room(
         }
     
     room = ChatRoom(
-        user1_id=current_user.id,
+        user1_id=current_user_id,
         user2_id=user2_id
     )
     db.add(room)
@@ -1462,18 +1466,22 @@ def create_chat_room(
 
 @app.post("/chat/{room_id}/send-message")
 async def send_chat_message(
-    room_id: str,
+    room_id: int,
     message_text: str = Form(None),
     media: UploadFile = File(None),
-    current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db)
 ):
+    """Send a chat message without requiring authentication.
+
+    The sender is assumed to be user id 3.
+    """
+    current_user_id = 3
 
     room = db.query(ChatRoom).filter(ChatRoom.id == room_id).first()
     if not room:
         raise HTTPException(status_code=404, detail="Chat room not found")
 
-    if current_user.id not in [room.user1_id, room.user2_id]:
+    if current_user_id not in [room.user1_id, room.user2_id]:
         raise HTTPException(status_code=403, detail="Not a member of this chat room")
     
     media_url = None
@@ -1486,7 +1494,7 @@ async def send_chat_message(
     
     message = ChatMessage(
         chat_room_id=room_id,
-        sender_id=current_user.id,
+        sender_id=current_user_id,
         message_text=message_text,
         media_url=media_url,
         media_type=media_type
@@ -1507,11 +1515,12 @@ async def send_chat_message(
 
 @app.get("/chat/rooms")
 def get_chat_rooms(
-    current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db)
 ):
+    """Return chat rooms for the default user id 3 without authentication."""
+    current_user_id = 3
     rooms = db.query(ChatRoom).filter(
-        (ChatRoom.user1_id == current_user.id) | (ChatRoom.user2_id == current_user.id)
+        (ChatRoom.user1_id == current_user_id) | (ChatRoom.user2_id == current_user_id)
     ).order_by(ChatRoom.updated_at.desc()).all()
     return [{
         "id": str(room.id),
@@ -1523,17 +1532,18 @@ def get_chat_rooms(
 
 @app.get("/chat/{room_id}/messages")
 def get_chat_messages(
-    room_id: str,
+    room_id: int,
     skip: int = 0,
     limit: int = 50,
-    current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db)
 ):
+    """Retrieve chat messages for the default user id 3 without authentication."""
+    current_user_id = 3
     room = db.query(ChatRoom).filter(ChatRoom.id == room_id).first()
     if not room:
         raise HTTPException(status_code=404, detail="Chat room not found")
 
-    if current_user.id not in [room.user1_id, room.user2_id]:
+    if current_user_id not in [room.user1_id, room.user2_id]:
         raise HTTPException(status_code=403, detail="Not a member of this chat room")
 
     messages = db.query(ChatMessage).filter(


### PR DESCRIPTION
## Summary
- disable authentication dependency for all chat endpoints
- hardcode user id 3 for chat room and message logic
- switch chat models to integer IDs

## Testing
- `python -m py_compile api.py`
- `pytest -q`
